### PR TITLE
Clearer error message for ignore rule failures

### DIFF
--- a/app/phantomjs-script.js
+++ b/app/phantomjs-script.js
@@ -116,7 +116,7 @@ page.open(url, function(status) {
 
             invoker(isRemoved, function(err) {
                 if (err) {
-                    console.log('Unable to remove DOM element: \'' + component.ignore + '\'' +
+                    console.log('Unable to hide DOM element: \'' + component.ignore + '\'' +
                         ', timed out after ' + (maxTries * tryTimeout) + ' ms.');
                     return phantom.exit(1);
                 }

--- a/app/phantomjs-script.js
+++ b/app/phantomjs-script.js
@@ -116,7 +116,7 @@ page.open(url, function(status) {
 
             invoker(isRemoved, function(err) {
                 if (err) {
-                    console.log('Unable to remove DOM element: \'' + component.selector + '\'' +
+                    console.log('Unable to remove DOM element: \'' + component.ignore + '\'' +
                         ', timed out after ' + (maxTries * tryTimeout) + ' ms.');
                     return phantom.exit(1);
                 }


### PR DESCRIPTION
Made small changes to the error displayed when a ignore selector can't be found. Now the actual selector is show to the user.